### PR TITLE
Phase 1: Style Profile System - Backend API and Built-in Profiles

### DIFF
--- a/backend/src/db/database.ts
+++ b/backend/src/db/database.ts
@@ -2,6 +2,7 @@ import Database from 'better-sqlite3';
 import { readFileSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
+import { seedBuiltinProfiles } from './seeds/builtinProfiles.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -12,6 +13,9 @@ const db = new Database(join(__dirname, '../../data/stylecheck.db'));
 // Read and execute schema
 const schema = readFileSync(join(__dirname, 'schema.sql'), 'utf-8');
 db.exec(schema);
+
+// Seed built-in profiles
+seedBuiltinProfiles(db);
 
 console.log('Database initialized successfully');
 

--- a/backend/src/db/seeds/builtinProfiles.ts
+++ b/backend/src/db/seeds/builtinProfiles.ts
@@ -1,0 +1,347 @@
+import Database from 'better-sqlite3';
+
+interface ProfileData {
+  name: string;
+  description: string;
+  author: string;
+  languages: string[];
+  preferences: Record<string, unknown>;
+  custom_rules: string[];
+}
+
+export const builtinProfiles: ProfileData[] = [
+  // 1. Minimal Profile
+  {
+    name: 'Minimal',
+    description: 'Lean preferences focusing only on critical style issues',
+    author: 'StyleCheck Team',
+    languages: ['python', 'javascript', 'typescript'],
+    preferences: {
+      naming: {
+        variables: 'flexible',
+        functions: 'flexible',
+        classes: 'descriptive',
+      },
+      organization: {
+        max_function_length: 200,
+        imports_grouped: false,
+      },
+      documentation: {
+        comment_style: 'minimal',
+        docstring_format: 'optional',
+      },
+      typing: {
+        coverage: 'none',
+        return_annotations: 'none',
+      },
+      structure: {
+        line_length: 120,
+        blank_lines: 'liberal',
+      },
+      error_handling: {
+        validation: 'optimistic',
+        logging: 'minimal',
+      },
+      practices: {
+        prefer_f_strings: false,
+        allow_walrus: true,
+      },
+    },
+    custom_rules: ['Avoid duplicate code', 'Keep it simple'],
+  },
+
+  // 2. PEP 8 Profile
+  {
+    name: 'PEP 8',
+    description: 'Standard Python style guide (PEP 8) compliance',
+    author: 'StyleCheck Team',
+    languages: ['python'],
+    preferences: {
+      naming: {
+        variables: 'snake_case',
+        functions: 'snake_case',
+        classes: 'PascalCase',
+        constants: 'UPPER_CASE',
+      },
+      organization: {
+        max_function_length: 50,
+        imports_grouped: true,
+        import_order: 'stdlib, third-party, local',
+      },
+      documentation: {
+        comment_style: 'moderate',
+        docstring_format: 'google',
+      },
+      typing: {
+        coverage: 'recommended',
+        return_annotations: 'public_functions',
+      },
+      structure: {
+        line_length: 79,
+        blank_lines: 'conservative',
+        indent_size: 4,
+      },
+      error_handling: {
+        validation: 'balanced',
+        logging: 'moderate',
+      },
+      practices: {
+        prefer_f_strings: true,
+        allow_walrus: false,
+      },
+    },
+    custom_rules: [
+      'Follow PEP 8 naming conventions',
+      'Maximum line length 79 characters',
+      'Use 4 spaces for indentation',
+      'Two blank lines between top-level definitions',
+    ],
+  },
+
+  // 3. Google Style Profile
+  {
+    name: 'Google Style',
+    description: "Google's Python style guide conventions",
+    author: 'StyleCheck Team',
+    languages: ['python'],
+    preferences: {
+      naming: {
+        variables: 'snake_case',
+        functions: 'snake_case',
+        classes: 'CapWords',
+        constants: 'CAPS_WITH_UNDERSCORES',
+      },
+      organization: {
+        max_function_length: 60,
+        imports_grouped: true,
+        import_order: 'stdlib, third-party, local',
+      },
+      documentation: {
+        comment_style: 'detailed',
+        docstring_format: 'google',
+        require_docstrings: true,
+      },
+      typing: {
+        coverage: 'comprehensive',
+        return_annotations: 'always',
+        modern_syntax: true,
+      },
+      structure: {
+        line_length: 80,
+        blank_lines: 'conservative',
+        indent_size: 4,
+      },
+      error_handling: {
+        validation: 'defensive',
+        logging: 'extensive',
+        explicit_exceptions: true,
+      },
+      practices: {
+        prefer_f_strings: true,
+        allow_walrus: true,
+        use_type_hints: true,
+      },
+    },
+    custom_rules: [
+      'All public functions must have docstrings',
+      'Use Google-style docstring format',
+      'Prefer explicit over implicit',
+      'Use type hints for all function signatures',
+    ],
+  },
+
+  // 4. Type-Safe Profile
+  {
+    name: 'Type-Safe',
+    description: 'Heavy emphasis on type annotations and type safety',
+    author: 'StyleCheck Team',
+    languages: ['python', 'typescript'],
+    preferences: {
+      naming: {
+        variables: 'snake_case',
+        functions: 'verb_first',
+        classes: 'PascalCase',
+      },
+      organization: {
+        max_function_length: 50,
+        imports_grouped: true,
+        separate_type_imports: true,
+      },
+      documentation: {
+        comment_style: 'moderate',
+        docstring_format: 'detailed',
+      },
+      typing: {
+        coverage: 'comprehensive',
+        return_annotations: 'always',
+        parameter_annotations: 'always',
+        modern_syntax: true,
+        strict_optional: true,
+      },
+      structure: {
+        line_length: 100,
+        blank_lines: 'conservative',
+      },
+      error_handling: {
+        validation: 'defensive',
+        logging: 'extensive',
+        typed_exceptions: true,
+      },
+      practices: {
+        prefer_f_strings: true,
+        allow_walrus: true,
+        immutability_preferred: true,
+      },
+    },
+    custom_rules: [
+      'All function parameters must have type hints',
+      'All return types must be annotated',
+      'Use mypy strict mode',
+      'Avoid Any type except when absolutely necessary',
+      'Prefer TypedDict over dict for structured data',
+    ],
+  },
+
+  // 5. Pragmatic Profile
+  {
+    name: 'Pragmatic',
+    description: 'Balanced, readability-focused pragmatic style',
+    author: 'StyleCheck Team',
+    languages: ['python', 'javascript', 'typescript'],
+    preferences: {
+      naming: {
+        variables: 'descriptive',
+        functions: 'verb_first',
+        classes: 'descriptive',
+      },
+      organization: {
+        max_function_length: 75,
+        imports_grouped: true,
+        logical_grouping: true,
+      },
+      documentation: {
+        comment_style: 'explain_why',
+        docstring_format: 'concise',
+      },
+      typing: {
+        coverage: 'balanced',
+        return_annotations: 'complex_functions',
+      },
+      structure: {
+        line_length: 100,
+        blank_lines: 'readable',
+        visual_alignment: true,
+      },
+      error_handling: {
+        validation: 'balanced',
+        logging: 'actionable',
+        fail_fast: true,
+      },
+      practices: {
+        prefer_f_strings: true,
+        allow_walrus: true,
+        readability_over_cleverness: true,
+      },
+    },
+    custom_rules: [
+      'Code should be self-documenting',
+      'Comments explain why, not what',
+      'Optimize for readability',
+      'Avoid premature optimization',
+      'Prefer simple over clever',
+    ],
+  },
+
+  // 6. Strict Profile
+  {
+    name: 'Strict',
+    description: 'Very opinionated style that catches everything',
+    author: 'StyleCheck Team',
+    languages: ['python', 'javascript', 'typescript'],
+    preferences: {
+      naming: {
+        variables: 'snake_case',
+        functions: 'verb_first',
+        classes: 'PascalCase',
+        constants: 'UPPER_CASE',
+        private_prefix: '_',
+      },
+      organization: {
+        max_function_length: 30,
+        max_class_length: 200,
+        imports_grouped: true,
+        import_order: 'alphabetical',
+        one_import_per_line: true,
+      },
+      documentation: {
+        comment_style: 'comprehensive',
+        docstring_format: 'detailed',
+        require_docstrings: true,
+        require_type_hints_in_docstrings: true,
+      },
+      typing: {
+        coverage: 'complete',
+        return_annotations: 'always',
+        parameter_annotations: 'always',
+        variable_annotations: 'complex_types',
+        modern_syntax: true,
+        strict_optional: true,
+      },
+      structure: {
+        line_length: 88,
+        blank_lines: 'strict',
+        indent_size: 4,
+        trailing_commas: 'always',
+      },
+      error_handling: {
+        validation: 'paranoid',
+        logging: 'extensive',
+        explicit_exceptions: true,
+        no_bare_except: true,
+      },
+      practices: {
+        prefer_f_strings: true,
+        allow_walrus: false,
+        immutability_preferred: true,
+        no_mutable_defaults: true,
+        explicit_is_better: true,
+      },
+    },
+    custom_rules: [
+      'Every function must have a docstring',
+      'Every public API must have type annotations',
+      'No functions longer than 30 lines',
+      'No classes longer than 200 lines',
+      'All imports must be absolute',
+      'No wildcard imports',
+      'No mutable default arguments',
+      'Always use context managers for resources',
+      'Prefer composition over inheritance',
+      'Single responsibility principle strictly enforced',
+    ],
+  },
+];
+
+export function seedBuiltinProfiles(db: Database.Database): void {
+  const insert = db.prepare(`
+    INSERT OR IGNORE INTO profiles (
+      name, description, author, languages, preferences, custom_rules, is_builtin
+    ) VALUES (?, ?, ?, ?, ?, ?, true)
+  `);
+
+  const insertMany = db.transaction((profiles: ProfileData[]) => {
+    for (const profile of profiles) {
+      insert.run(
+        profile.name,
+        profile.description,
+        profile.author,
+        JSON.stringify(profile.languages),
+        JSON.stringify(profile.preferences),
+        JSON.stringify(profile.custom_rules)
+      );
+    }
+  });
+
+  insertMany(builtinProfiles);
+  console.log(`Seeded ${builtinProfiles.length} built-in profiles`);
+}

--- a/backend/src/routes/profiles.ts
+++ b/backend/src/routes/profiles.ts
@@ -1,0 +1,223 @@
+import { Router, Request, Response } from 'express';
+import db from '../db/database.js';
+
+const router = Router();
+
+interface Profile {
+  id?: number;
+  name: string;
+  description?: string;
+  author?: string;
+  languages?: string[];
+  preferences: Record<string, unknown>;
+  custom_rules?: string[];
+  reference_guide_path?: string;
+  is_builtin?: boolean;
+  created_at?: string;
+  updated_at?: string;
+}
+
+// GET /api/profiles - List all profiles
+router.get('/profiles', (req: Request, res: Response) => {
+  try {
+    const profiles = db
+      .prepare('SELECT * FROM profiles ORDER BY is_builtin DESC, name ASC')
+      .all();
+    res.json(profiles);
+  } catch (error) {
+    console.error('Error fetching profiles:', error);
+    res.status(500).json({ error: 'Failed to fetch profiles' });
+  }
+});
+
+// GET /api/profiles/:id - Get single profile
+router.get('/profiles/:id', (req: Request, res: Response) => {
+  try {
+    const profile = db
+      .prepare('SELECT * FROM profiles WHERE id = ?')
+      .get(req.params.id);
+
+    if (!profile) {
+      return res.status(404).json({ error: 'Profile not found' });
+    }
+
+    res.json(profile);
+  } catch (error) {
+    console.error('Error fetching profile:', error);
+    res.status(500).json({ error: 'Failed to fetch profile' });
+  }
+});
+
+// POST /api/profiles - Create new profile
+router.post('/profiles', (req: Request, res: Response) => {
+  const {
+    name,
+    description,
+    author,
+    languages,
+    preferences,
+    custom_rules,
+    reference_guide_path,
+  } = req.body as Profile;
+
+  // Validation
+  if (!name || !preferences) {
+    return res.status(400).json({
+      error: 'Name and preferences are required',
+    });
+  }
+
+  try {
+    const result = db
+      .prepare(
+        `INSERT INTO profiles (
+          name, description, author, languages, preferences,
+          custom_rules, reference_guide_path, is_builtin
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, false)`
+      )
+      .run(
+        name,
+        description || null,
+        author || null,
+        JSON.stringify(languages || []),
+        JSON.stringify(preferences),
+        JSON.stringify(custom_rules || []),
+        reference_guide_path || null
+      );
+
+    res.status(201).json({
+      id: result.lastInsertRowid,
+      message: 'Profile created successfully',
+    });
+  } catch (error: unknown) {
+    console.error('Error creating profile:', error);
+
+    // Handle unique constraint violation
+    if (error instanceof Error && error.message.includes('UNIQUE')) {
+      return res.status(400).json({
+        error: 'Profile name already exists',
+      });
+    }
+
+    res.status(500).json({ error: 'Failed to create profile' });
+  }
+});
+
+// PUT /api/profiles/:id - Update profile
+router.put('/profiles/:id', (req: Request, res: Response) => {
+  const profileId = req.params.id;
+
+  try {
+    // Check if profile exists and if it's built-in
+    const existingProfile = db
+      .prepare('SELECT is_builtin FROM profiles WHERE id = ?')
+      .get(profileId) as { is_builtin: number } | undefined;
+
+    if (!existingProfile) {
+      return res.status(404).json({ error: 'Profile not found' });
+    }
+
+    if (existingProfile.is_builtin) {
+      return res.status(403).json({
+        error: 'Cannot modify built-in profiles',
+      });
+    }
+
+    const {
+      name,
+      description,
+      author,
+      languages,
+      preferences,
+      custom_rules,
+      reference_guide_path,
+    } = req.body as Profile;
+
+    // Build dynamic update query based on provided fields
+    const updates: string[] = [];
+    const values: unknown[] = [];
+
+    if (name !== undefined) {
+      updates.push('name = ?');
+      values.push(name);
+    }
+    if (description !== undefined) {
+      updates.push('description = ?');
+      values.push(description);
+    }
+    if (author !== undefined) {
+      updates.push('author = ?');
+      values.push(author);
+    }
+    if (languages !== undefined) {
+      updates.push('languages = ?');
+      values.push(JSON.stringify(languages));
+    }
+    if (preferences !== undefined) {
+      updates.push('preferences = ?');
+      values.push(JSON.stringify(preferences));
+    }
+    if (custom_rules !== undefined) {
+      updates.push('custom_rules = ?');
+      values.push(JSON.stringify(custom_rules));
+    }
+    if (reference_guide_path !== undefined) {
+      updates.push('reference_guide_path = ?');
+      values.push(reference_guide_path);
+    }
+
+    if (updates.length === 0) {
+      return res.status(400).json({ error: 'No fields to update' });
+    }
+
+    updates.push('updated_at = CURRENT_TIMESTAMP');
+    values.push(profileId);
+
+    const query = `UPDATE profiles SET ${updates.join(', ')} WHERE id = ?`;
+    db.prepare(query).run(...values);
+
+    res.json({ message: 'Profile updated successfully' });
+  } catch (error: unknown) {
+    console.error('Error updating profile:', error);
+
+    // Handle unique constraint violation
+    if (error instanceof Error && error.message.includes('UNIQUE')) {
+      return res.status(400).json({
+        error: 'Profile name already exists',
+      });
+    }
+
+    res.status(500).json({ error: 'Failed to update profile' });
+  }
+});
+
+// DELETE /api/profiles/:id - Delete profile
+router.delete('/profiles/:id', (req: Request, res: Response) => {
+  const profileId = req.params.id;
+
+  try {
+    // Check if profile exists and if it's built-in
+    const profile = db
+      .prepare('SELECT is_builtin FROM profiles WHERE id = ?')
+      .get(profileId) as { is_builtin: number } | undefined;
+
+    if (!profile) {
+      return res.status(404).json({ error: 'Profile not found' });
+    }
+
+    if (profile.is_builtin) {
+      return res.status(403).json({
+        error: 'Cannot delete built-in profiles',
+      });
+    }
+
+    db.prepare('DELETE FROM profiles WHERE id = ?').run(profileId);
+
+    res.json({ message: 'Profile deleted successfully' });
+  } catch (error) {
+    console.error('Error deleting profile:', error);
+    res.status(500).json({ error: 'Failed to delete profile' });
+  }
+});
+
+export default router;

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1,6 +1,7 @@
 import express from 'express';
 import cors from 'cors';
 import db from './db/database.js';
+import profileRoutes from './routes/profiles.js';
 
 const app = express();
 const PORT = process.env.PORT || 3001;
@@ -18,8 +19,12 @@ app.get('/api/health', (req, res) => {
   });
 });
 
+// API Routes
+app.use('/api', profileRoutes);
+
 // Start server
 app.listen(PORT, () => {
   console.log(`Server running on http://localhost:${PORT}`);
   console.log(`Health check available at http://localhost:${PORT}/api/health`);
+  console.log(`Profiles API available at http://localhost:${PORT}/api/profiles`);
 });


### PR DESCRIPTION
## Summary

Implements Issue #8: Complete backend API for style profile management with 6 built-in profiles.

## Changes

**API Endpoints:**
- `GET /api/profiles` - List all profiles (built-in first, alphabetical)
- `GET /api/profiles/:id` - Get single profile by ID
- `POST /api/profiles` - Create new custom profile
- `PUT /api/profiles/:id` - Update custom profile (protected)
- `DELETE /api/profiles/:id` - Delete custom profile (protected)

**Built-in Profiles:**
1. **Minimal** - Lean preferences, critical issues only
2. **PEP 8** - Standard Python style guide compliance
3. **Google Style** - Google's Python conventions
4. **Type-Safe** - Heavy type annotation emphasis
5. **Pragmatic** - Balanced, readability-focused
6. **Strict** - Very opinionated, catches everything

**Implementation Details:**
- Built-in profile protection via `is_builtin` flag (403 Forbidden on modify/delete)
- Input validation (name and preferences required)
- UNIQUE constraint handling for duplicate names
- Dynamic UPDATE queries for flexible partial updates
- Database seeding on initialization with `INSERT OR IGNORE`
- Proper HTTP status codes (200, 201, 400, 403, 404, 500)
- JSON storage for languages, preferences, and custom_rules in SQLite

## Files Changed

- `backend/src/routes/profiles.ts` - CRUD API implementation (~230 lines)
- `backend/src/db/seeds/builtinProfiles.ts` - Profile data + seeding (~350 lines)
- `backend/src/db/database.ts` - Added seeding call
- `backend/src/server.ts` - Mounted profile routes

## Testing

✅ Manually tested all 5 CRUD endpoints with curl
✅ Verified built-in profile protection (403 on PUT/DELETE)
✅ Verified error handling (404 for not found, 400 for duplicates)
✅ Confirmed 6 profiles seeded successfully on server start
✅ Verified profile creation, update, and deletion workflows

## Next Steps

- Issue #9: Frontend UI for profile management
- Issue #10: Code analysis engine integration

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)